### PR TITLE
Update patch-glibc-CVE-2015-0235.yml

### DIFF
--- a/patch-glibc-CVE-2015-0235.yml
+++ b/patch-glibc-CVE-2015-0235.yml
@@ -3,7 +3,7 @@
    gather_facts: false
    sudo: true
    vars:
-      glibc_search: "lsof -n |grep -v init | grep -v udevd | grep -v getty | grep -v 'upstart-' | grep -v 'xe-daemon' | grep 'DEL.*libc-'" 
+      glibc_search: "lsof -n |grep -v init | grep -v udevd | grep -v getty | grep -v 'upstart-' | grep -v 'xe-daemon' | grep 'DEL.*libc-'|sort -k1,1 -u|awk '{ print $1 }'" 
       glibc_packages: ["libc-bin", "libc-dev-bin", "libc6", "libc6-dev"]
       affected_services:
         - nginx
@@ -37,6 +37,7 @@
         - opendkim
         - driveclient
         - logstash-forwarder
+        - ssh
    tasks:
      - name: ensure glibc is the latest version
        with_items: glibc_packages


### PR DESCRIPTION
cosmetic patch for `glibc_search:`, adding `ssh` to affected services
